### PR TITLE
[chore] fix workflow's setup-java and distribution 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: SetupJDK 21
-              uses: actions/setup-java@4
+            - name: SetupJDK21
+              uses: actions/setup-java@v3
               with:
                 java-version: '21'
                 distribution: 'temurin'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
               uses: actions/setup-java@4
               with:
                 java-version: '21'
+                distribution: 'temurin'
 
             - name: Setup sbt
               uses: sbt/setup-sbt@v1


### PR DESCRIPTION
Fixed a workflow error where it wouldn't start if it wasn't provided a jdk distribution 